### PR TITLE
fix: handle ampersand in category name

### DIFF
--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -14,7 +14,7 @@
             {{- if site.Params.blog.list.displayTags -}}
               {{ with .Params.tags }}
                 <p class="hx-opacity-50 hx-text-sm hx-leading-7">
-                  {{- range . }}<a class="hx-inline-block hx-mr-2"href="{{ (urlize (printf " tags/%s/" . )) | absLangURL }}">#{{ . }}</a>{{ end -}}
+                  {{- range . }}<a class="hx-inline-block hx-mr-2"href="{{ anchorize . | printf "tags/%s/" | absLangURL }}">#{{ . }}</a>{{ end -}}
                 </p>
               {{ end -}}
             {{- end -}}
@@ -26,7 +26,7 @@
             </p>
             <p class="hx-opacity-50 hx-text-sm hx-mt-4 hx-leading-7">{{ partial "utils/format-date" .Date }} |
             {{ with .Params.categories }}
-                {{- range . }}<a class=" hx-font-semibold hx-mr-2" href="{{ (urlize (printf " categories/%s/" . )) | absLangURL }}">{{ . | humanize }}</a>{{ end -}}
+                {{- range . }}<a class=" hx-font-semibold hx-mr-2" href="{{ anchorize . | printf "categories/%s/" | absLangURL }}">{{ . | humanize }}</a>{{ end -}}
               {{ end -}}
             </p>
 

--- a/layouts/categories/list.html
+++ b/layouts/categories/list.html
@@ -15,7 +15,7 @@
             {{- if site.Params.blog.list.displayTags -}}
               {{ with .Params.tags }}
                 <p class="hx-opacity-50 hx-text-sm hx-leading-7">
-                  {{- range . }}<a class="hx-inline-block hx-mr-2" href="{{ (urlize (printf " tags/%s/" . )) | absLangURL }}">#{{ . }}</a>{{ end -}}
+                  {{- range . }}<a class="hx-inline-block hx-mr-2" href="{{ anchorize . | printf "tags/%s/" | absLangURL }}">#{{ . }}</a>{{ end -}}
                 </p>
               {{ end -}}
             {{- end -}}
@@ -28,7 +28,7 @@
             <p class="hx-opacity-50 hx-text-sm hx-mt-4 hx-leading-7">
             {{ partial "utils/format-date" .Date }} | 
             {{ with .Params.categories }}
-                {{- range . }}<a class=" hx-font-semibold hx-mr-2" href="{{ (urlize (printf " categories/%s/" . )) | absLangURL }}">{{ . | humanize }}</a>{{ end -}}
+                {{- range . }}<a class=" hx-font-semibold hx-mr-2" href="{{ anchorize . | printf "categories/%s" | absLangURL }}">{{ . | humanize }}</a>{{ end -}}
               {{ end -}}
             </p>
           </div>

--- a/layouts/tags/list.html
+++ b/layouts/tags/list.html
@@ -15,7 +15,7 @@
             {{- if site.Params.blog.list.displayTags -}}
               {{ with .Params.tags }}
                 <p class="hx-opacity-50 hx-text-sm hx-leading-7">
-                  {{- range . }}<a class="hx-inline-block hx-mr-2" href="{{ (urlize (printf " tags/%s/" . )) | absLangURL }}">#{{ . }}</a>{{ end -}}
+                  {{- range . }}<a class="hx-inline-block hx-mr-2" href="{{ anchorize . | printf "tags/%s/" | absLangURL }}">#{{ . }}</a>{{ end -}}
                 </p>
               {{ end -}}
             {{- end -}}
@@ -28,7 +28,7 @@
             <p class="hx-opacity-50 hx-text-sm hx-mt-4 hx-leading-7">
             {{ partial "utils/format-date" .Date }} | 
             {{ with .Params.categories }}
-                {{- range . }}<a class="hx-font-semibold hx-mr-2" href="{{ (urlize (printf " categories/%s/" . )) | absLangURL }}">{{ . | humanize }}</a>{{ end -}}
+                {{- range . }}<a class="hx-font-semibold hx-mr-2" href="{{ anchorize . | printf "categories/%s/" | absLangURL }}">{{ . | humanize }}</a>{{ end -}}
               {{ end -}}
             </p>
           </div>


### PR DESCRIPTION
This would fix the problem of having incorrect redirection when a category's name contains an ampersand

The rendered HTML has the correct URL now
![image](https://github.com/user-attachments/assets/afba9577-284b-4e32-833e-3cf6fd10a40e)